### PR TITLE
Fix construct check

### DIFF
--- a/packages/aws-cdk-lib/aws-lambda-event-sources/lib/kafka.ts
+++ b/packages/aws-cdk-lib/aws-lambda-event-sources/lib/kafka.ts
@@ -245,7 +245,7 @@ export class SelfManagedKafkaEventSource extends StreamEventSource {
   }
 
   public bind(target: lambda.IFunction) {
-    if (!(target instanceof Construct)) { throw new Error('Function is not a construct. Unexpected error.'); }
+    if (!(Construct.isConstruct(target))) { throw new Error('Function is not a construct. Unexpected error.'); }
     target.addEventSourceMapping(
       this.mappingId(target),
       this.enrichMappingOptions({


### PR DESCRIPTION
### Reason for this change

Allow SelfManagedKafkaEventSource to be used in symlinked setups.

### Description of changes

Replace instanceof check by `Construct.isConstruct()` call.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
